### PR TITLE
feat: add URL scheme and hostname when shortening an URL

### DIFF
--- a/app/controllers/dynamic_links/v1/short_links_controller.rb
+++ b/app/controllers/dynamic_links/v1/short_links_controller.rb
@@ -1,14 +1,7 @@
 class DynamicLinks::V1::ShortLinksController < ApplicationController
   def create
     url = params.require(:url)
-    # validate url
-    # if !url_shortener.valid_url?(url)
-    #   render json: { error: 'invalid url' }, status: :bad_request
-    #   return
-    # end
-
-    # shorten url
-    # save to db (not implemented yet)
-    render json: DynamicLinks.generate_short_url(url), status: :created
+    client = DynamicLinks::Client.find_by!(api_key: params.require(:api_key))
+    render json: DynamicLinks.generate_short_url(url, client), status: :created
   end
 end

--- a/app/controllers/dynamic_links/v1/short_links_controller.rb
+++ b/app/controllers/dynamic_links/v1/short_links_controller.rb
@@ -1,7 +1,12 @@
 class DynamicLinks::V1::ShortLinksController < ApplicationController
   def create
     url = params.require(:url)
-    client = DynamicLinks::Client.find_by!(api_key: params.require(:api_key))
+    client = DynamicLinks::Client.find_by(api_key: params.require(:api_key))
+    unless client
+      render json: { error: 'invalid api key' }, status: :unauthorized
+      return
+    end
+
     render json: DynamicLinks.generate_short_url(url, client), status: :created
   end
 end

--- a/app/models/dynamic_links/client.rb
+++ b/app/models/dynamic_links/client.rb
@@ -15,7 +15,11 @@
 #
 module DynamicLinks
   class Client < ApplicationRecord
+    VALID_SCHEMES = ['http', 'https'].freeze
+
     validates :name, presence: true, uniqueness: true
     validates :api_key, presence: true, uniqueness: true
+    validates :hostname, presence: true, uniqueness: true
+    validates :scheme, presence: true, inclusion: { in: VALID_SCHEMES }
   end
 end

--- a/app/models/dynamic_links/shortened_url.rb
+++ b/app/models/dynamic_links/shortened_url.rb
@@ -20,6 +20,6 @@ module DynamicLinks
     belongs_to :client, optional: true
 
     validates :url, presence: true
-    validates :short_url, presence: true, uniqueness: true
+    validates :short_url, presence: true, uniqueness: { scope: :client_id }
   end
 end

--- a/db/migrate/20231228175142_create_dynamic_links_shortened_urls.rb
+++ b/db/migrate/20231228175142_create_dynamic_links_shortened_urls.rb
@@ -11,7 +11,7 @@ class CreateDynamicLinksShortenedUrls < ActiveRecord::Migration[7.1]
       # 2083 is the maximum length of a URL according to the RFC 2616
       t.string :url, null: false, limit: 2083
       # 12 is the maximum length of a short URL if we use the RedisCounterStrategy
-      t.string :short_url, null: false, limit: DynamicLinks::ShorteningStrategies::RedisCounterStrategy::MAX_LENGTH
+      t.string :short_url, null: false, limit: 20
       t.datetime :expires_at
       t.timestamps
     end

--- a/db/migrate/20231228175142_create_dynamic_links_shortened_urls.rb
+++ b/db/migrate/20231228175142_create_dynamic_links_shortened_urls.rb
@@ -16,6 +16,6 @@ class CreateDynamicLinksShortenedUrls < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :dynamic_links_shortened_urls, :short_url, unique: true
+    add_index :dynamic_links_shortened_urls, [:client_id, :short_url], unique: true
   end
 end

--- a/db/migrate/20240101102216_add_scheme_and_hostname_to_clients.rb
+++ b/db/migrate/20240101102216_add_scheme_and_hostname_to_clients.rb
@@ -1,0 +1,8 @@
+class AddSchemeAndHostnameToClients < ActiveRecord::Migration[7.1]
+  def change
+    add_column :dynamic_links_clients, :hostname, :string, null: false
+    add_index :dynamic_links_clients, :hostname, unique: true
+
+    add_column :dynamic_links_clients, :scheme, :string, default: 'https', null: false
+  end
+end

--- a/lib/dynamic_links.rb
+++ b/lib/dynamic_links.rb
@@ -23,7 +23,7 @@ module DynamicLinks
     end
   end
 
-  def self.shorten_url(url)
+  def self.shorten_url(url, client)
     strategy_key = configuration.shortening_strategy
 
     begin
@@ -37,12 +37,15 @@ module DynamicLinks
       raise "Unexpected error while initializing the strategy: #{e.message}"
     end
 
-    strategy.shorten(url)
+    short_url = strategy.shorten(url)
+
+    short_url_record = ShortenedUrl.create!(client: client, url: url, short_url: short_url)
+    "#{client.scheme}://#{client.hostname}/#{short_url}"
   end
 
   # mimic Firebase Dynamic Links API
-  def self.generate_short_url(original_url)
-    short_link = shorten_url(original_url)
+  def self.generate_short_url(original_url, client)
+    short_link = shorten_url(original_url, client)
 
     {
       shortLink: short_link,

--- a/lib/dynamic_links.rb
+++ b/lib/dynamic_links.rb
@@ -40,7 +40,7 @@ module DynamicLinks
     short_url = strategy.shorten(url)
 
     short_url_record = ShortenedUrl.create!(client: client, url: url, short_url: short_url)
-    "#{client.scheme}://#{client.hostname}/#{short_url}"
+    URI::Generic.build({scheme: client.scheme, host: client.hostname, path: "/#{short_url}"}).to_s
   end
 
   # mimic Firebase Dynamic Links API

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -33,8 +33,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_01_102216) do
     t.datetime "expires_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["client_id", "short_url"], name: "index_dynamic_links_shortened_urls_on_client_id_and_short_url", unique: true
     t.index ["client_id"], name: "index_dynamic_links_shortened_urls_on_client_id"
-    t.index ["short_url"], name: "index_dynamic_links_shortened_urls_on_short_url", unique: true
   end
 
   add_foreign_key "dynamic_links_shortened_urls", "dynamic_links_clients", column: "client_id"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_28_175142) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_01_102216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,14 +19,17 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_28_175142) do
     t.string "api_key", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "hostname", null: false
+    t.string "scheme", default: "https", null: false
     t.index ["api_key"], name: "index_dynamic_links_clients_on_api_key", unique: true
+    t.index ["hostname"], name: "index_dynamic_links_clients_on_hostname", unique: true
     t.index ["name"], name: "index_dynamic_links_clients_on_name", unique: true
   end
 
   create_table "dynamic_links_shortened_urls", force: :cascade do |t|
     t.bigint "client_id"
     t.string "url", limit: 2083, null: false
-    t.string "short_url", limit: 10, null: false
+    t.string "short_url", limit: 20, null: false
     t.datetime "expires_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/fixtures/dynamic_links/clients.yml
+++ b/test/fixtures/dynamic_links/clients.yml
@@ -17,7 +17,11 @@
 one:
   name: "Test Client One"
   api_key: "api_key_one"
+  hostname: client-one.com
+  scheme: https
 
 two:
   name: "Test Client Two"
   api_key: "api_key_two"
+  hostname: client-two.com
+  scheme: http

--- a/test/models/dynamic_links/client_test.rb
+++ b/test/models/dynamic_links/client_test.rb
@@ -20,29 +20,39 @@ module DynamicLinks
     self.use_transactional_tests = true
 
     test 'should not save client without name' do
-      client = Client.new(api_key: 'unique_api_key')
+      client = Client.new(api_key: 'unique_api_key', hostname: 'example.com', scheme: 'https')
       assert_not client.save, 'Saved client without a name'
     end
 
     test 'should not save client without api_key' do
-      client = Client.new(name: 'Unique Name')
+      client = Client.new(name: 'Unique Name', hostname: 'example.com', scheme: 'https')
       assert_not client.save, 'Saved client without an api_key'
     end
 
-    test 'should save client with name and api_key' do
-      client = Client.new(name: 'Test Client', api_key: 'test_api_key')
+    test 'should not save client without hostname' do
+      client = Client.new(name: 'Unique Name', api_key: 'unique_api_key', scheme: 'https')
+      assert_not client.save, 'Saved client without a hostname'
+    end
+
+    test 'should not save client with invalid scheme' do
+      client = Client.new(name: 'Unique Name', api_key: 'unique_api_key', hostname: 'example.com', scheme: 'invalid')
+      assert_not client.save, 'Saved client with an invalid scheme'
+    end
+
+    test 'should save client with name, api_key, hostname, and valid scheme' do
+      client = Client.new(name: 'Test Client', api_key: 'test_api_key', hostname: 'example.com', scheme: 'https')
       assert client.save, 'Failed to save valid client'
     end
 
     test 'should not save client with duplicate api_key' do
-      Client.create!(name: 'Test Client', api_key: 'test_api_key')
-      duplicate_client = Client.new(name: 'Test Client 2', api_key: 'test_api_key')
+      Client.create!(name: 'Test Client', api_key: 'test_api_key', hostname: 'example.com', scheme: 'https')
+      duplicate_client = Client.new(name: 'Test Client 2', api_key: 'test_api_key', hostname: 'example2.com', scheme: 'https')
       assert_not duplicate_client.save, 'Saved client with a duplicate api_key'
     end
 
     test 'should not save client with duplicate name' do
-      Client.create!(name: 'Test Client', api_key: 'test_api_key')
-      duplicate_client = Client.new(name: 'Test Client', api_key: 'test_api_key1')
+      Client.create!(name: 'Test Client', api_key: 'test_api_key', hostname: 'example.com', scheme: 'https')
+      duplicate_client = Client.new(name: 'Test Client', api_key: 'test_api_key1', hostname: 'example2.com', scheme: 'https')
       assert_not duplicate_client.save, 'Saved client with a duplicate name'
     end
   end

--- a/test/models/dynamic_links/shortened_url_test.rb
+++ b/test/models/dynamic_links/shortened_url_test.rb
@@ -55,5 +55,24 @@ module DynamicLinks
       shortened_url = ShortenedUrl.new(url: 'https://example.com', short_url: 'xyz789')
       assert shortened_url.save, 'Failed to save shortened url without an associated client'
     end
+
+    test 'should allow the same short_url for different clients' do
+      client_one = dynamic_links_clients(:one)
+      client_two = dynamic_links_clients(:two)
+
+      url_one = DynamicLinks::ShortenedUrl.create!(client: client_one, url: 'https://example.com', short_url: 'foobar')
+      url_two = DynamicLinks::ShortenedUrl.new(client: client_two, url: 'https://example.org', short_url: 'foobar')
+
+      assert url_two.valid?, 'ShortenedUrl with duplicate short_url but different client should be valid'
+    end
+
+    test 'should not allow the same short_url for the same client' do
+      client = dynamic_links_clients(:one)
+
+      DynamicLinks::ShortenedUrl.create!(client: client, url: 'https://example.com', short_url: 'xyz789')
+      duplicate_url = DynamicLinks::ShortenedUrl.new(client: client, url: 'https://example.org', short_url: 'xyz789')
+
+      assert_not duplicate_url.valid?, 'ShortenedUrl with duplicate short_url for the same client should not be valid'
+    end
   end
 end


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the URL shortening service to include URL scheme and hostname, providing more context and security.
- Refactor: Updated the `ShortenedUrl` model to ensure uniqueness of `short_url` within the scope of a specific client, allowing for better organization and management of URLs.
- Test: Added new test cases to validate the changes in URL shortening logic and the uniqueness of `short_url` per client.
- Chore: Performed database schema updates, adding `scheme` and `hostname` fields to the `dynamic_links_clients` table and extending the length of `short_url` in the `dynamic_links_shortened_urls` table.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->