### PR TITLE
feat: configure activerecord-multi-tenant from GitHub and update Redis settings in tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+RAILS_ENV=development
+
+# PostgreSQL configuration
+POSTGRES_DB=dynamic_links_development
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_HOST=citus
+POSTGRES_PORT=5432
+DATABASE_URL=postgres://postgres:postgres@citus:5432/dynamic_links_development
+
+# Redis configuration
+REDIS_URL=redis://redis:6379/1
+REDIS_HOST=redis
+
+CITUS_ENABLED=true

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -76,6 +76,7 @@ jobs:
         POSTGRES_PORT: 5432
         RAILS_MAX_THREADS: 5
         SHORTENING_STRATEGY: md5
+        REDIS_HOST: localhost
       run: |
         bundle exec rails db:drop db:create db:migrate
         bundle exec rails db:test:prepare
@@ -93,6 +94,7 @@ jobs:
         RAILS_MAX_THREADS: 5
         CITUS_ENABLED: 'true'
         SHORTENING_STRATEGY: md5
+        REDIS_HOST: localhost
       run: |
         bundle exec rails db:drop db:create db:migrate
         bundle exec rails db:test:prepare

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -2,9 +2,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [master, main]
   pull_request:
-    branches: [ master, main ]
+    branches: [master, main]
 
 jobs:
   test:
@@ -38,71 +38,71 @@ jobs:
 
     strategy:
       matrix:
-        db_type: ['standard', 'citus']
+        db_type: ["standard", "citus"]
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '3.2'
-        bundler-cache: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: false
 
-    - name: Install gem dependencies
-      run: gem install bundler
+      - name: Install gem dependencies
+        run: gem install bundler
 
-    - name: Install bundle dependencies for standard PostgreSQL
-      if: matrix.db_type == 'standard'
-      env:
-        CITUS_ENABLED: 'false'
-      run: bundle install --jobs 4 --retry 3
+      - name: Install bundle dependencies for standard PostgreSQL
+        if: matrix.db_type == 'standard'
+        env:
+          CITUS_ENABLED: "false"
+        run: bundle install --jobs 4 --retry 3
 
-    - name: Install bundle dependencies for Citus
-      if: matrix.db_type == 'citus'
-      env:
-        CITUS_ENABLED: 'true'
-      run: bundle install --jobs 4 --retry 3
+      - name: Install bundle dependencies for Citus
+        if: matrix.db_type == 'citus'
+        env:
+          CITUS_ENABLED: "true"
+        run: bundle install --jobs 4 --retry 3
 
-    - name: Run tests with standard PostgreSQL
-      if: matrix.db_type == 'standard'
-      env:
-        RAILS_ENV: test
-        POSTGRES_DB: dynamic_links
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: postgres
-        POSTGRES_HOST: localhost
-        POSTGRES_PORT: 5432
-        RAILS_MAX_THREADS: 5
-        SHORTENING_STRATEGY: md5
-        REDIS_HOST: localhost
-      run: |
-        bundle exec rails db:drop db:create db:migrate
-        bundle exec rails db:test:prepare
-        bundle exec rails test
+      - name: Run tests with standard PostgreSQL
+        if: matrix.db_type == 'standard'
+        env:
+          RAILS_ENV: test
+          POSTGRES_DB: dynamic_links
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          RAILS_MAX_THREADS: 5
+          SHORTENING_STRATEGY: md5
+          REDIS_HOST: localhost
+        run: |
+          bundle exec rails db:drop db:create db:migrate
+          bundle exec rails db:test:prepare
+          bundle exec rails test
 
-    - name: Run tests with Citus
-      if: matrix.db_type == 'citus'
-      env:
-        RAILS_ENV: test
-        POSTGRES_DB: dynamic_links
-        POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: postgres
-        POSTGRES_HOST: localhost
-        POSTGRES_PORT: 5432
-        RAILS_MAX_THREADS: 5
-        CITUS_ENABLED: 'true'
-        SHORTENING_STRATEGY: md5
-        REDIS_HOST: localhost
-      run: |
-        bundle exec rails db:drop db:create db:migrate
-        bundle exec rails db:test:prepare
-        bundle exec rails test
+      - name: Run tests with Citus
+        if: matrix.db_type == 'citus'
+        env:
+          RAILS_ENV: test
+          POSTGRES_DB: dynamic_links
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          RAILS_MAX_THREADS: 5
+          CITUS_ENABLED: "true"
+          SHORTENING_STRATEGY: md5
+          REDIS_HOST: localhost
+        run: |
+          bundle exec rails db:drop db:create db:migrate
+          bundle exec rails db:test:prepare
+          bundle exec rails test
 
-    - name: Upload coverage report
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: coverage-report
-        path: coverage/
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report-${{ matrix.db_type }}
+          path: coverage/

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 # Specify your gem's dependencies in dynamic_links.gemspec.
 gemspec
 
-gem 'dotenv-rails', require: 'dotenv/rails-now'
+gem 'dotenv-rails', require: 'dotenv/load'
 
 gem 'puma'
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,5 @@ end
 # gem "debug", ">= 1.0.0"
 
 if ENV['CITUS_ENABLED'] == 'true'
-  gem 'activerecord-multi-tenant'
+  gem 'activerecord-multi-tenant', github: 'citusdata/activerecord-multi-tenant', branch: 'master'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/citusdata/activerecord-multi-tenant.git
+  revision: 3b21347810d662d8a9ff3c1d62f9b28f933b97d8
+  branch: master
+  specs:
+    activerecord-multi-tenant (2.4.0)
+      rails (>= 6)
+
 PATH
   remote: .
   specs:
@@ -231,6 +239,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-multi-tenant!
   annotate
   dotenv-rails
   dynamic_links!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DynamicLinks
 
+[![Unit Tests](https://github.com/saiqulhaq/dynamic_links/actions/workflows/unit_test.yml/badge.svg)](https://github.com/saiqulhaq/dynamic_links/actions/workflows/unit_test.yml)
+
 DynamicLinks is a flexible URL shortening Ruby gem, designed to provide various strategies for URL shortening, similar to Firebase Dynamic Links.
 
 By default, encoding strategies such as MD5 will generate the same short URL for the same input URL. This behavior ensures consistency and prevents the creation of multiple records for identical URLs. For scenarios requiring unique short URLs for each request, strategies like RedisCounterStrategy can be used, which generate a new short URL every time, regardless of the input URL.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - citus
       - redis
     command: sleep infinity # Keep container running
+    environment:
+      CITUS_ENABLED: "true"
     user: vscode
 
   citus:

--- a/test/lib/shortening_strategies/redis_counter_strategy_test.rb
+++ b/test/lib/shortening_strategies/redis_counter_strategy_test.rb
@@ -3,6 +3,17 @@ require_relative './../../../lib/dynamic_links/strategy_factory'
 
 class DynamicLinks::ShorteningStrategies::RedisCounterStrategyTest < ActiveSupport::TestCase
   def setup
+    # Make sure we're using the redis host from environment
+    redis_config = {
+      host: ENV.fetch('REDIS_HOST', 'redis'),
+      port: ENV.fetch('REDIS_PORT', 6379).to_i,
+      db: ENV.fetch('REDIS_DB', 0).to_i
+    }
+
+    # Create a new configuration with the proper Redis settings
+    config = DynamicLinks::RedisConfig.new(redis_config)
+    DynamicLinks.configuration.redis_counter_config = config
+
     @url_shortener = DynamicLinks::StrategyFactory.get_strategy(:redis_counter)
   end
 

--- a/test/lib/shortening_strategies/redis_counter_strategy_test.rb
+++ b/test/lib/shortening_strategies/redis_counter_strategy_test.rb
@@ -5,7 +5,7 @@ class DynamicLinks::ShorteningStrategies::RedisCounterStrategyTest < ActiveSuppo
   def setup
     # Make sure we're using the redis host from environment
     redis_config = {
-      host: ENV.fetch('REDIS_HOST', 'redis'),
+      host: ENV.fetch('REDIS_HOST', 'localhost'),
       port: ENV.fetch('REDIS_PORT', 6379).to_i,
       db: ENV.fetch('REDIS_DB', 0).to_i
     }


### PR DESCRIPTION
### **User description**



___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Point activerecord-multi-tenant to GitHub

- Enable CITUS_ENABLED env in Docker Compose

- Configure RedisCounterStrategy tests using ENV


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>redis_counter_strategy_test.rb</strong><dd><code>Configure test Redis settings via ENV</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/lib/shortening_strategies/redis_counter_strategy_test.rb

<li>Fetch Redis host, port, and db from ENV<br> <li> Initialize DynamicLinks::RedisConfig with ENV values<br> <li> Assign config to DynamicLinks.configuration.redis_counter_config


</details>


  </td>
  <td><a href="https://github.com/saiqulhaq/dynamic_links/pull/98/files#diff-fead14f796156ff3325ae16707a4c5aa301f4dac26bf819bfcf045b2f63843cf">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Point activerecord-multi-tenant to GitHub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Gemfile

<li>Update activerecord-multi-tenant gem source<br> <li> Point to GitHub repo: citusdata/activerecord-multi-tenant<br> <li> Specify branch: master


</details>


  </td>
  <td><a href="https://github.com/saiqulhaq/dynamic_links/pull/98/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Enable Citus in Docker Compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Add CITUS_ENABLED environment variable to app service<br> <li> Ensure Citus service is enabled in compose setup


</details>


  </td>
  <td><a href="https://github.com/saiqulhaq/dynamic_links/pull/98/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

---
- Refactor: Updated the 'activerecord-multi-tenant' gem to pull from a specific GitHub repository and branch, improving compatibility with Citus when enabled.
- New Feature: Added environment variable configurations for PostgreSQL, Redis, and Citus in the development environment, enhancing flexibility and ease of setup.
- Chore: Modified Docker Compose configuration to include `REDIS_HOST` for jobs where `CITUS_ENABLED` is set to 'true', ensuring proper Redis connectivity.
- Test: Enhanced `DynamicLinks::ShorteningStrategies::RedisCounterStrategyTest` setup method to use environment variables for Redis configuration, improving test reliability.
---
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->