### PR TITLE
feat: add Rack::Attack rate limiting with trusted-IP safelist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,3 +96,13 @@ ELASTIC_APM_SERVICE_NAME=rails-dynamic-links
 
 # Elastic APM environment
 ELASTIC_APM_ENVIRONMENT=development
+
+# ==============================================================================
+# RATE LIMITING (RACK::ATTACK)
+# ==============================================================================
+
+# Comma-separated list of trusted IP addresses that bypass all rate limits.
+# Typically set to the NAT gateway IPs of your internal infrastructure
+# (e.g. EKS/GKE cluster egress IPs) so internal services are never throttled.
+# Example: RACK_ATTACK_TRUSTED_IPS=10.0.0.1,10.0.0.2
+RACK_ATTACK_TRUSTED_IPS=

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'sidekiq', '~> 8.0'
 # Admin interface [https://avohq.io]
 gem 'avo'
 
+# Rate limiting middleware [https://github.com/rack/rack-attack]
+gem 'rack-attack'
+
 # Application Performance Monitoring (conditionally loaded based on configuration)
 require_elastic_apm = ENV.fetch('ELASTIC_APM_ENABLED', 'false').downcase == 'true'
 gem 'elastic-apm', require: require_elastic_apm

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.3)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-mini-profiler (4.0.1)
       rack (>= 1.2.0)
     rack-session (2.1.1)
@@ -437,6 +439,7 @@ DEPENDENCIES
   pg (~> 1.6)
   propshaft (~> 1.3)
   puma (~> 6.4)
+  rack-attack
   rack-mini-profiler
   rails (~> 8.1.0.rc1)
   redis (~> 5.2)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Safelist trusted IPs loaded from RACK_ATTACK_TRUSTED_IPS (comma-separated).
+# These addresses bypass all throttle checks — intended for internal
+# infrastructure egress IPs (e.g. Kubernetes NAT gateway addresses).
+trusted_ips = ENV.fetch('RACK_ATTACK_TRUSTED_IPS', '').split(',').map(&:strip).reject(&:empty?)
+trusted_ips.each do |ip|
+  Rack::Attack.safelist("trusted/#{ip}") { |req| req.ip == ip }
+end
+
+# Default throttle: 60 requests per second per IP for all other clients.
+Rack::Attack.throttle('req/ip', limit: 60, period: 1) do |req|
+  req.ip unless trusted_ips.include?(req.ip)
+end
+
+# Return 429 JSON on throttle instead of the default plain-text response.
+Rack::Attack.throttled_responder = lambda do |_req|
+  [429, { 'Content-Type' => 'application/json' }, ['{"error":"Too Many Requests"}']]
+end

--- a/deploy/k8s/production/deployment.yaml
+++ b/deploy/k8s/production/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rails-dynamic-links
+  namespace: cosmos-public
+  labels:
+    app: rails-dynamic-links
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: rails-dynamic-links
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+  template:
+    metadata:
+      labels:
+        app: rails-dynamic-links
+    spec:
+      terminationGracePeriodSeconds: 30
+      containers:
+        - name: rails-dynamic-links
+          image: registry.digitalocean.com/hh-staging/dynamic-links-app:0.5.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          env:
+            - name: RAILS_LOG_TO_STDOUT
+              value: "true"
+            - name: RAILS_SERVE_STATIC_FILES
+              value: "true"
+          envFrom:
+            - configMapRef:
+                name: rails-dynamic-links-config
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 200m
+              memory: 512Mi
+          volumeMounts:
+            - name: rack-attack-config
+              mountPath: /app/config/initializers/rack_attack.rb
+              subPath: rack_attack.rb
+      volumes:
+        - name: rack-attack-config
+          configMap:
+            name: rails-dynamic-links-rack-attack

--- a/deploy/k8s/production/rack-attack-configmap.yaml
+++ b/deploy/k8s/production/rack-attack-configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rails-dynamic-links-rack-attack
+  namespace: cosmos-public
+data:
+  rack_attack.rb: |
+    # frozen_string_literal: true
+
+    # Safelist trusted IPs (loaded from RACK_ATTACK_TRUSTED_IPS env var).
+    # These addresses bypass all throttle checks.
+    trusted_ips = ENV.fetch('RACK_ATTACK_TRUSTED_IPS', '').split(',').map(&:strip).reject(&:empty?)
+    trusted_ips.each do |ip|
+      Rack::Attack.safelist("trusted/#{ip}") { |req| req.ip == ip }
+    end
+
+    # Default throttle: 60 requests per second per IP for all other clients.
+    Rack::Attack.throttle('req/ip', limit: 60, period: 1) do |req|
+      req.ip unless trusted_ips.include?(req.ip)
+    end
+
+    # Return 429 JSON on throttle.
+    Rack::Attack.throttled_responder = lambda do |_req|
+      [429, { 'Content-Type' => 'application/json' }, ['{"error":"Too Many Requests"}']]
+    end


### PR DESCRIPTION
## Summary

- Adds `rack-attack` gem to `Gemfile` / `Gemfile.lock` (v6.8.0 — already present in the deployed image, now made explicit)
- Adds `config/initializers/rack_attack.rb` with:
  - **Safelist** for trusted infrastructure IPs via `RACK_ATTACK_TRUSTED_IPS` env var (comma-separated; bypasses all throttle checks)
  - **Default throttle**: 60 requests per second per IP for all other clients; returns `429 {"error":"Too Many Requests"}` on breach
- Updates `.env.example` with `RACK_ATTACK_TRUSTED_IPS` documentation
- Adds `deploy/k8s/production/` with the production Kubernetes `Deployment` and `ConfigMap` manifests

## Background

The `RACK_ATTACK_TRUSTED_IPS` env var was already pre-configured in the production ConfigMap (pointing to the EKS cluster NAT gateway IPs) but no initializer existed to consume it. This PR wires it up and makes the rate limiting configuration explicit in source.

Until a new image is built from this branch, the initializer is mounted via a ConfigMap volume in the production deployment (see `deploy/k8s/production/`).

## Test plan

- [ ] `bundle install` succeeds with the new gem entry
- [ ] Boot the app locally; confirm `Rack::Attack` appears in `rails middleware` output
- [ ] Set `RACK_ATTACK_TRUSTED_IPS=127.0.0.1` and verify localhost requests are safelisted
- [ ] Fire >60 requests/s from an untrusted IP and confirm 429 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)